### PR TITLE
Add BigQuery Table Viewer to Streamlit App

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,26 @@ WHERE
 ORDER BY
   rating DESC;
 
+## BigQuery Table Viewer
+
+The application now includes a "BigQuery Table Viewer" accessible via the sidebar navigation.
+
+### How to Use
+
+1.  **Navigate to the Viewer:** Select "BigQuery Table Viewer" from the sidebar.
+2.  **Enter Table URI:** In the input field, provide the BigQuery table URI in the format `project_id.dataset_id.table_id`.
+    *   Example: `my-gcp-project.my_dataset.my_table`
+3.  **Load Table:** Click the "Load Table" button.
+4.  **View Data:** If the URI is correct and you have permissions, the table data will be displayed.
+
+### Important Notes
+
+*   **Authentication:** Ensure you are authenticated with Google Cloud and have the necessary permissions to read the specified BigQuery table. Typically, running `gcloud auth application-default login` locally is sufficient if your user account has "BigQuery Data Viewer" role (or equivalent) on the project/dataset/table.
+*   **Error Handling:** The viewer includes basic error handling for:
+    *   Invalid URI format.
+    *   Table not found.
+    *   Permission denied.
+
 ## Streamlit Frontend for Restaurant Finder
 
 This Streamlit application provides a user interface for the Restaurant Finder. You can upload a CSV file containing geolocations (latitude, longitude, and an optional radius in km per point) to find restaurants in those areas.

--- a/bq_table_viewer.py
+++ b/bq_table_viewer.py
@@ -1,0 +1,47 @@
+import streamlit as st
+import pandas as pd
+from google.cloud import bigquery
+from google.api_core.exceptions import NotFound, Forbidden
+
+def display_bq_table():
+    st.title("BigQuery Table Viewer")
+
+    bq_uri = st.text_input("Enter BigQuery Table URI (e.g., project_id.dataset_id.table_id)", "")
+    load_button = st.button("Load Table")
+
+    if load_button and bq_uri:
+        try:
+            if len(bq_uri.split('.')) != 3:
+                st.error("Invalid BigQuery URI format. Please use 'project_id.dataset_id.table_id'")
+                return
+
+            client = bigquery.Client()
+            table_ref = client.get_table(bq_uri) # Try to get table to check existence and basic permissions
+
+            st.info(f"Fetching table: {bq_uri}")
+            
+            # Construct the query
+            query = f"SELECT * FROM `{bq_uri}`" # Use backticks for safety with special characters in names
+            
+            # Execute the query
+            query_job = client.query(query)
+            
+            # Convert to Pandas DataFrame
+            df = query_job.to_dataframe()
+            
+            st.success(f"Successfully loaded table: {bq_uri}")
+            st.dataframe(df)
+
+        except Forbidden:
+            st.error(f"Permission denied for table: {bq_uri}. Ensure you have the necessary BigQuery permissions (e.g., BigQuery Data Viewer role).")
+        except NotFound:
+            st.error(f"Table not found: {bq_uri}. Please check the Project ID, Dataset ID, and Table ID.")
+        except Exception as e:
+            st.error(f"An error occurred: {e}")
+    elif load_button and not bq_uri:
+        st.warning("Please enter a BigQuery Table URI.")
+
+if __name__ == "__main__":
+    # This allows the page to be run independently for testing if needed,
+    # though it will primarily be imported and called by streamlit_app.py
+    display_bq_table()

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -12,7 +12,10 @@ except ImportError as e:
     # You might want to stop the app here or provide more specific instructions
     # For now, we'll let it potentially fail later if the import didn't work.
 
-def main():
+# Import for BigQuery Table Viewer
+from bq_table_viewer import display_bq_table
+
+def restaurant_finder_app(): # Renamed from main
     st.title("Restaurant Finder")
 
     # --- UI Elements ---
@@ -212,3 +215,22 @@ if __name__ == "__main__":
     st.info("This usually means the `restaurant_finder.main` module was not found. "
                 "Ensure the Streamlit app is launched from a context where this module is in the Python path, "
                 "or that the path adjustments in `app.py` are correct.")
+
+def main():
+    st.sidebar.title("Navigation")
+    app_choice = st.sidebar.radio("Choose App", ["Restaurant Finder", "BigQuery Table Viewer"])
+
+    if app_choice == "Restaurant Finder":
+        # Check if find_restaurants_in_batches was imported successfully before running restaurant_finder_app
+        if 'find_restaurants_in_batches' in globals() and 'get_latlong_from_bucket' in globals():
+            restaurant_finder_app()
+        else:
+            st.error("Restaurant Finder app cannot start because a backend function failed to import. "
+                     "This usually means the `restaurant_finder.main` module was not found or there's an issue with its dependencies.")
+            st.info("Ensure the Streamlit app is launched from a context where this module is in the Python path.")
+            # Optionally, you could display a message or part of the UI that doesn't depend on these imports
+    elif app_choice == "BigQuery Table Viewer":
+        display_bq_table()
+
+if __name__ == "__main__":
+    main() # Call the new main function


### PR DESCRIPTION
This commit introduces a new subpage to the Streamlit application that allows you to view BigQuery tables.

Features:
- A new "BigQuery Table Viewer" accessible via sidebar navigation.
- You can input a BigQuery table URI (project_id.dataset_id.table_id).
- The application fetches and displays the table data using `st.dataframe`.
- Includes error handling for invalid URIs, tables not found, and permission issues.

Changes:
- Created `bq_table_viewer.py` containing the logic for the new page.
- Modified `streamlit_app.py` to include sidebar navigation and conditionally display the selected page.
- Updated `README.md` with instructions for using the new viewer and authentication notes.
- Verified that `google-cloud-bigquery` is in `requirements.txt`.